### PR TITLE
Sort plans by GitLab priority

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,17 +23,22 @@ class MapPriorityAction(argparse.Action):
         super().__init__(option_strings, dest, nargs=nargs, **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
-        if not (len(values) % 2 == 0):
+        if not len(values) % 2 == 0:
             raise argparse.ArgumentTypeError("Priority assignment items list "
                                              "must have even length")
 
-        setattr(namespace, self.dest, {})
+        result = {}
         for key, val in batched(values, n=2):
             priority = int(key)
+            label = str(val)
             if priority not in (1,2,3,4,5,6,99):
                 raise argparse.ArgumentTypeError("Thunderdome priority must be one of "
                                                  "1,2,3,4,5,6,99")
-            getattr(namespace, self.dest)[int(key)] = str(val)
+            result[label] = priority
+
+        result = dict(sorted(result.items(), key=lambda item: item[1]))
+
+        setattr(namespace, self.dest, result)
 
 
 def parse_args() -> argparse.Namespace:

--- a/main.py
+++ b/main.py
@@ -29,8 +29,8 @@ class MapPriorityAction(argparse.Action):
 
         result = {}
         for key, val in batched(values, n=2):
-            priority = int(key)
-            label = str(val)
+            label = str(key)
+            priority = int(val)
             if priority not in (1,2,3,4,5,6,99):
                 raise argparse.ArgumentTypeError("Thunderdome priority must be one of "
                                                  "1,2,3,4,5,6,99")
@@ -107,8 +107,8 @@ def parse_args() -> argparse.Namespace:
                                help=("Include GitLab items in the battle "
                                "that are closed"))
 
-    create_parser.add_argument("--map-priority", action=MapPriorityAction, nargs="*",
-                               help="Map Thunderdome priorities to GitLab labels")
+    create_parser.add_argument("--label-priority", action=MapPriorityAction, nargs="*",
+                               help="Map GitLab labels to Thunderdome priorities")
 
     return parser.parse_args()
 


### PR DESCRIPTION
Adds the `--label-priority` flag that can map GitLab labels to Thunderdome priority levels. This can be used when creating a game to sort the plans by priority.